### PR TITLE
Fix: msgpack can't encode StringName

### DIFF
--- a/addons/godot_colyseus/lib/msgpack.gd
+++ b/addons/godot_colyseus/lib/msgpack.gd
@@ -102,7 +102,7 @@ static func _encode(buf, value, ctx):
 			buf.put_u8(0xcb)
 			buf.put_double(value)
 
-		TYPE_STRING:
+		TYPE_STRING, TYPE_STRING_NAME:
 			var bytes = value.to_utf8_buffer()
 
 			var size = bytes.size()


### PR DESCRIPTION
The [demo script](https://github.com/gsioteam/godot-colyseus/blob/4.0/addons/godot_colyseus/demo/main.gd) isn't working because in [these `room.send` lines](https://github.com/gsioteam/godot-colyseus/blob/4.0/addons/godot_colyseus/demo/main.gd#L62) the dictionary literal keys are type [`StringName`](https://docs.godotengine.org/en/stable/classes/class_stringname.html#stringname) and [msgpack.gd](https://github.com/gsioteam/godot-colyseus/blob/4.0/addons/godot_colyseus/lib/msgpack.gd) doesn't have a case for encoding them.

I guess this is more an issue for the original godot-msgpack project, but I'm unsure whether they intend to support Godot 4.0.

I can write up a more formal GH issue to go with this PR if you'd like. I have demo server and Godot projects I could provide.  